### PR TITLE
Update Readme as this is the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-  modImplementation "com.lettuce.fudge:artifice:0.8.1+1.16.1"
-  include "com.lettuce.fudge:artifice:0.8.1+1.16.1"
+  modImplementation "com.lettuce.fudge:artifice:0.8.1+1.16.2-rc1"
+  include "com.lettuce.fudge:artifice:0.8.1+1.16.2-rc1"
 }
 ```


### PR DESCRIPTION
causes an error when you try to use the old version.