### PR TITLE
Add a Smithing Table recipe type

### DIFF
--- a/src/main/java/com/swordglowsblue/artifice/api/ArtificeResourcePack.java
+++ b/src/main/java/com/swordglowsblue/artifice/api/ArtificeResourcePack.java
@@ -18,7 +18,6 @@ import com.swordglowsblue.artifice.api.virtualpack.ArtificeResourcePackContainer
 import com.swordglowsblue.artifice.common.ClientOnly;
 import com.swordglowsblue.artifice.common.ClientResourcePackProfileLike;
 import com.swordglowsblue.artifice.common.ServerResourcePackProfileLike;
-import com.swordglowsblue.artifice.impl.ArtificeImpl;
 import com.swordglowsblue.artifice.impl.ArtificeResourcePackImpl;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -449,6 +448,6 @@ public interface ArtificeResourcePack extends ResourcePack, ServerResourcePackPr
          * @param id The ID of the recipe, which will be converted into the correct path.
          * @param f  A callback which will be passed a {@link CookingRecipeBuilder} to create the recipe.
          */
-        void addSmithingRecipe(Identifier id, Processor<SmithingTableRecipeBuilder> f);
+        void addSmithingRecipe(Identifier id, Processor<SmithingRecipeBuilder> f);
     }
 }

--- a/src/main/java/com/swordglowsblue/artifice/api/ArtificeResourcePack.java
+++ b/src/main/java/com/swordglowsblue/artifice/api/ArtificeResourcePack.java
@@ -442,5 +442,13 @@ public interface ArtificeResourcePack extends ResourcePack, ServerResourcePackPr
          * @param f  A callback which will be passed a {@link CookingRecipeBuilder} to create the recipe.
          */
         void addCampfireRecipe(Identifier id, Processor<CookingRecipeBuilder> f);
+
+        /**
+         * Add a smithing table recipe with the given ID.
+         *
+         * @param id The ID of the recipe, which will be converted into the correct path.
+         * @param f  A callback which will be passed a {@link CookingRecipeBuilder} to create the recipe.
+         */
+        void addSmithingRecipe(Identifier id, Processor<SmithingTableRecipeBuilder> f);
     }
 }

--- a/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingRecipeBuilder.java
+++ b/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingRecipeBuilder.java
@@ -3,6 +3,7 @@ package com.swordglowsblue.artifice.api.builder.data.recipe;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.swordglowsblue.artifice.api.builder.JsonObjectBuilder;
+import com.swordglowsblue.artifice.api.util.Processor;
 import net.minecraft.util.Identifier;
 
 /**
@@ -36,6 +37,16 @@ public class SmithingRecipeBuilder extends RecipeBuilder<SmithingRecipeBuilder> 
     }
 
     /**
+     * Set the item being smithed as one of a list of options.
+     * @param settings A callback which will be passed a {@link MultiIngredientBuilder}.
+     * @return this
+     */
+    public SmithingRecipeBuilder multiBase(Processor<MultiIngredientBuilder> settings) {
+        root.add("base", settings.process(new MultiIngredientBuilder()).build());
+        return this;
+    }
+
+    /**
      * Set the item to be added on during the smithing
      * @param id The item ID
      * @return this
@@ -52,6 +63,16 @@ public class SmithingRecipeBuilder extends RecipeBuilder<SmithingRecipeBuilder> 
      * */
     public SmithingRecipeBuilder additionTag(Identifier id) {
         root.add("addition", tag(id));
+        return this;
+    }
+
+    /**
+     * Set the item being added on as one of a list of options.
+     * @param settings A callback which will be passed a {@link MultiIngredientBuilder}.
+     * @return this
+     */
+    public SmithingRecipeBuilder multiAddition(Processor<MultiIngredientBuilder> settings) {
+        root.add("addition", settings.process(new MultiIngredientBuilder()).build());
         return this;
     }
 

--- a/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingRecipeBuilder.java
+++ b/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingRecipeBuilder.java
@@ -5,33 +5,33 @@ import com.google.gson.JsonPrimitive;
 import com.swordglowsblue.artifice.api.builder.JsonObjectBuilder;
 import net.minecraft.util.Identifier;
 
-public class SmithingTableRecipeBuilder extends RecipeBuilder<SmithingTableRecipeBuilder> {
-    public SmithingTableRecipeBuilder() {
+public class SmithingRecipeBuilder extends RecipeBuilder<SmithingRecipeBuilder> {
+    public SmithingRecipeBuilder() {
         super();
         type(new Identifier("smithing"));
     }
 
-    public SmithingTableRecipeBuilder baseItem(Identifier id) {
+    public SmithingRecipeBuilder baseItem(Identifier id) {
         root.add("base", item(id));
         return this;
     }
 
-    public SmithingTableRecipeBuilder baseTag(Identifier id) {
+    public SmithingRecipeBuilder baseTag(Identifier id) {
         root.add("base", tag(id));
         return this;
     }
 
-    public SmithingTableRecipeBuilder additionItem(Identifier id) {
+    public SmithingRecipeBuilder additionItem(Identifier id) {
         root.add("addition", item(id));
         return this;
     }
 
-    public SmithingTableRecipeBuilder additionTag(Identifier id) {
+    public SmithingRecipeBuilder additionTag(Identifier id) {
         root.add("addition", tag(id));
         return this;
     }
 
-    public SmithingTableRecipeBuilder result(Identifier id) {
+    public SmithingRecipeBuilder result(Identifier id) {
         root.add("result", new JsonPrimitive(id.toString()));
         return this;
     }

--- a/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingRecipeBuilder.java
+++ b/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingRecipeBuilder.java
@@ -5,32 +5,62 @@ import com.google.gson.JsonPrimitive;
 import com.swordglowsblue.artifice.api.builder.JsonObjectBuilder;
 import net.minecraft.util.Identifier;
 
+/**
+ * Builder for a smithing recipe ({@code namespace:recipes/id.json}).
+ * @see <a href="https://minecraft.gamepedia.com/Recipe#JSON_format" target="_blank">Minecraft Wiki</a>
+ */
 public class SmithingRecipeBuilder extends RecipeBuilder<SmithingRecipeBuilder> {
     public SmithingRecipeBuilder() {
         super();
         type(new Identifier("smithing"));
     }
 
+    /**
+     * Set the item being smithed
+     * @param id The item ID
+     * @return this
+     * */
     public SmithingRecipeBuilder baseItem(Identifier id) {
         root.add("base", item(id));
         return this;
     }
 
+    /**
+     * Set the item being smithed to be any one of the given tag
+     * @param id The tag ID
+     * @return this
+     * */
     public SmithingRecipeBuilder baseTag(Identifier id) {
         root.add("base", tag(id));
         return this;
     }
 
+    /**
+     * Set the item to be added on during the smithing
+     * @param id The item ID
+     * @return this
+     * */
     public SmithingRecipeBuilder additionItem(Identifier id) {
         root.add("addition", item(id));
         return this;
     }
 
+    /**
+     * Set the item to be added on to be any one of the given tag
+     * @param id The ta ID
+     * @return this
+     * */
     public SmithingRecipeBuilder additionTag(Identifier id) {
         root.add("addition", tag(id));
         return this;
     }
 
+    /**
+     * Set the result of the smithing.
+     * Item NBT will be preserved.
+     * @param id The ID of the resulting item
+     * @return this
+     * */
     public SmithingRecipeBuilder result(Identifier id) {
         root.add("result", new JsonPrimitive(id.toString()));
         return this;

--- a/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingTableRecipeBuilder.java
+++ b/src/main/java/com/swordglowsblue/artifice/api/builder/data/recipe/SmithingTableRecipeBuilder.java
@@ -1,0 +1,46 @@
+package com.swordglowsblue.artifice.api.builder.data.recipe;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.swordglowsblue.artifice.api.builder.JsonObjectBuilder;
+import net.minecraft.util.Identifier;
+
+public class SmithingTableRecipeBuilder extends RecipeBuilder<SmithingTableRecipeBuilder> {
+    public SmithingTableRecipeBuilder() {
+        super();
+        type(new Identifier("smithing"));
+    }
+
+    public SmithingTableRecipeBuilder baseItem(Identifier id) {
+        root.add("base", item(id));
+        return this;
+    }
+
+    public SmithingTableRecipeBuilder baseTag(Identifier id) {
+        root.add("base", tag(id));
+        return this;
+    }
+
+    public SmithingTableRecipeBuilder additionItem(Identifier id) {
+        root.add("addition", item(id));
+        return this;
+    }
+
+    public SmithingTableRecipeBuilder additionTag(Identifier id) {
+        root.add("addition", tag(id));
+        return this;
+    }
+
+    public SmithingTableRecipeBuilder result(Identifier id) {
+        root.add("result", new JsonPrimitive(id.toString()));
+        return this;
+    }
+
+    private JsonObject item(Identifier id) {
+        return new JsonObjectBuilder().add("item", id.toString()).build();
+    }
+
+    private JsonObject tag(Identifier id) {
+        return new JsonObjectBuilder().add("tag", id.toString()).build();
+    }
+}

--- a/src/main/java/com/swordglowsblue/artifice/impl/ArtificeResourcePackImpl.java
+++ b/src/main/java/com/swordglowsblue/artifice/impl/ArtificeResourcePackImpl.java
@@ -362,8 +362,8 @@ public class ArtificeResourcePackImpl implements ArtificeResourcePack {
         }
 
         @Override
-        public void addSmithingRecipe(Identifier id, Processor<SmithingTableRecipeBuilder> f) {
-            this.add("recipes/", id, ".json", r -> f.process(r.type(new Identifier("blasting"))), SmithingTableRecipeBuilder::new);
+        public void addSmithingRecipe(Identifier id, Processor<SmithingRecipeBuilder> f) {
+            this.add("recipes/", id, ".json", r -> f.process(r.type(new Identifier("blasting"))), SmithingRecipeBuilder::new);
         }
 
         private <T extends TypedJsonBuilder<? extends JsonResource>> void add(String path, Identifier id, String ext, Processor<T> f, Supplier<T> ctor) {

--- a/src/main/java/com/swordglowsblue/artifice/impl/ArtificeResourcePackImpl.java
+++ b/src/main/java/com/swordglowsblue/artifice/impl/ArtificeResourcePackImpl.java
@@ -361,6 +361,11 @@ public class ArtificeResourcePackImpl implements ArtificeResourcePack {
             this.add("recipes/", id, ".json", r -> f.process(r.type(new Identifier("campfire_cooking"))), CookingRecipeBuilder::new);
         }
 
+        @Override
+        public void addSmithingRecipe(Identifier id, Processor<SmithingTableRecipeBuilder> f) {
+            this.add("recipes/", id, ".json", r -> f.process(r.type(new Identifier("blasting"))), SmithingTableRecipeBuilder::new);
+        }
+
         private <T extends TypedJsonBuilder<? extends JsonResource>> void add(String path, Identifier id, String ext, Processor<T> f, Supplier<T> ctor) {
             this.add(IdUtils.wrapPath(path, id, ext), f.process(ctor.get()).build());
         }


### PR DESCRIPTION
This PR allows Artifice to generate smithing table recipes. I needed it for my mod and it was a pretty simple implementation, so I thought I'd submit a PR. It has documentation and support for items and tags, as well as multi-ingredient support

I hope you don't mind the little functions I put in `SmithingTableRecipeBuilder` just so I wouldn't have to type out a huge wodge of Gson code for every ingredient.